### PR TITLE
Allow the option to disply card decline reason

### DIFF
--- a/woocommerce-gateway-checkout-com/includes/api/class-wc-checkoutcom-api-request.php
+++ b/woocommerce-gateway-checkout-com/includes/api/class-wc-checkoutcom-api-request.php
@@ -84,7 +84,19 @@ class WC_Checkoutcom_Api_request
                     return $response;
                 }
             } else {
-                $error_message = __("An error has occurred while processing your payment. Please check your card details and try again. ", 'wc_checkout_com');
+                $showDeclineResponse = WC_Admin_Settings::get_option('ckocom_display_declines');
+
+                // If the merchant enabled decline reasons 
+                if($showDeclineResponse) {
+                    // Only show the decline reason in case the response code is not from a risk rule
+                    if(preg_match("/^(?:40)\d+$/",$response->response_code)) {
+                       $error_message = __("An error has occurred while processing your payment. Please check your card details and try again. ", 'wc_checkout_com');
+                    } else {
+                       $error_message = __($response->response_summary, 'wc_checkout_com');
+                    }
+                } else {
+                    $error_message = __("An error has occurred while processing your payment. Please check your card details and try again. ", 'wc_checkout_com');
+                }
 
                 // check if gateway response is enable from module settings
                 if ($gateway_debug) {

--- a/woocommerce-gateway-checkout-com/includes/settings/class-wc-checkoutcom-cards-settings.php
+++ b/woocommerce-gateway-checkout-com/includes/settings/class-wc-checkoutcom-cards-settings.php
@@ -312,6 +312,18 @@ class WC_Checkoutcom_Cards_Settings
                 'default' => 0,
                 'desc' => 'Select the styling for card iframe',
             ),
+            'ckocom_display_icon' => array(
+                'id' => 'ckocom_display_declines',
+                'title' => __('Display Decline Reason', 'checkoutcom-cards-settings'),
+                'type' => 'select',
+                'desc_tip' => true,
+                'options' => array(
+                    0   => __('No', 'checkoutcom-cards-settings'),
+                    1   => __('Yes', 'checkoutcom-cards-settings')
+                ),
+                'default' => 0,
+                'desc' => 'Enable/disable decline reasons on the checkout page. It will not display the decline reason for risk rule declines.',
+            ),
         );
 
         return apply_filters( 'wc_checkout_com_cards', $settings );


### PR DESCRIPTION
Add the option to display the Decline reason in the checkout page. 
- only show in case the option is enabled and the decline is not due to a risk rule (to avoid fraud)