### PR TITLE
update: version to 4.4.8 and changelog

### DIFF
--- a/languages/checkout-com-unified-payments-api.pot
+++ b/languages/checkout-com-unified-payments-api.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the same license as the Checkout.com Payment Gateway plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Checkout.com Payment Gateway 4.4.7\n"
+"Project-Id-Version: Checkout.com Payment Gateway 4.4.8\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/checkout-com-unified-payments-api\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-08-18T04:38:37+00:00\n"
+"POT-Creation-Date: 2022-11-04T12:23:22+05:30\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.6.0\n"
+"X-Generator: WP-CLI 2.7.1\n"
 "X-Domain: checkout-com-unified-payments-api\n"
 
 #. Plugin Name of the plugin

--- a/readme.txt
+++ b/readme.txt
@@ -171,6 +171,14 @@ http://example.com/?wc-api=wc_checkoutcom_webhook
 After the plugin has been configured, customers will be able to choose Checkout.com as a valid payment method.
 
 == Changelog ==
+v4.4.8 4th November 2022
+- **[fix]** Webhook notices logging.
+- **[fix]** Card holder name send undefined on add payment screen.
+- **[tweak]** Upgrade minimum required PHP version to 7.3
+- **[tweak]** Apple Pay button JS event.
+- **[tweak]** Gateway icon `woocommerce_gateway_icon` filter usage.
+- **[tweak]** Add Google Pay & Apple Pay icon for gateway list on checkout.
+
 v4.4.7 18th August 2022
 - **[fix]** Apple Pay MADA support.
 - **[fix]** Fix MOTO payment type.

--- a/woocommerce-gateway-checkout-com.php
+++ b/woocommerce-gateway-checkout-com.php
@@ -5,12 +5,12 @@
  * Description: Extends WooCommerce by Adding the Checkout.com Gateway.
  * Author: Checkout.com
  * Author URI: https://www.checkout.com/
- * Version: 4.4.7
+ * Version: 4.4.8
  * Requires at least: 4.0
- * Stable tag: 4.4.7
- * Tested up to: 6.0
- * WC tested up to: 6.5.1
- * Requires PHP: 7.2
+ * Stable tag: 4.4.8
+ * Tested up to: 6.1
+ * WC tested up to: 7.0.0
+ * Requires PHP: 7.3
  * Text Domain: checkout-com-unified-payments-api
  * Domain Path: /languages
  *
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Constants.
  */
-define( 'WC_CHECKOUTCOM_PLUGIN_VERSION', '4.4.7' );
+define( 'WC_CHECKOUTCOM_PLUGIN_VERSION', '4.4.8' );
 define( 'WC_CHECKOUTCOM_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'WC_CHECKOUTCOM_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 


### PR DESCRIPTION
- **[fix]** Webhook notices logging.
- **[fix]** Card holder name send undefined on add payment screen.
- **[tweak]** Upgrade minimum required PHP version to 7.3
- **[tweak]** Apple Pay button JS event.
- **[tweak]** Gateway icon `woocommerce_gateway_icon` filter usage.
- **[tweak]** Add Google Pay & Apple Pay icon for gateway list on checkout.