### PR TITLE
Provide SEPA address filter and fix translation missing string

### DIFF
--- a/includes/api/class-wc-checkoutcom-apm-method.php
+++ b/includes/api/class-wc-checkoutcom-apm-method.php
@@ -355,6 +355,8 @@ class WC_Checkoutcom_APM_Method {
 		$address->zip           = self::$post['billing_postcode'];
 		$address->country       = self::$post['billing_country'];
 
+		$address = apply_filters( 'checkout_apm_sepa_address', $address );
+
 		$source_data                     = new SourceData();
 		$source_data->first_name         = self::$post['billing_first_name'];
 		$source_data->last_name          = self::$post['billing_last_name'];

--- a/templates/class-wc-checkoutcom-apm-templates.php
+++ b/templates/class-wc-checkoutcom-apm-templates.php
@@ -111,7 +111,7 @@ class WC_Checkoutcom_Apm_Templates extends WC_Checkoutcom_Api_Request {
 				<input type="text" id="sepa-iban" name="sepa-iban" placeholder="<?php echo ( __( 'IBAN', 'checkout-com-unified-payments-api' ) ); ?>" class="input-control" required style="width: 100%;">
 			</div>
 			<div class="sepa-continue-btn">
-				<input type="button" id="sepa-continue" name="sepa-continue" value="Continue">
+				<input type="button" id="sepa-continue" name="sepa-continue" value="<?php esc_html_e( 'Continue', 'checkout-com-unified-payments-api' ); ?>">
 			</div>
 
 			<?php


### PR DESCRIPTION
```php
// Below is sample code of how to use filter, please modify it as per your requirement.

add_filter( 'checkout_apm_sepa_address', 'checkout_apm_sepa_address_filter' );

function checkout_apm_sepa_address_filter( $address ) {

	$address->address_line1 = some_filter_function( $address->address_line1 );
	$address->address_line2 = some_filter_function( $address->address_line2 );

	return $address;
}
```