### PR TITLE
Fix: 422 unprocessed entity error on Paypal Payment Gateway

### DIFF
--- a/assets/js/cko-paypal-integration.js
+++ b/assets/js/cko-paypal-integration.js
@@ -124,6 +124,12 @@ jQuery( function ( $ ) {
                     });
                 },
                 onCancel: function (data, actions) {
+                    fetch( cko_paypal_vars.clear_session_url, {
+                        method: 'GET',
+                        headers: {
+                            'Content-Type': 'application/x-www-form-urlencoded'
+                        },
+                    });
                     jQuery('.woocommerce').unblock();
                 },
                 onError: function (err) {
@@ -162,49 +168,4 @@ jQuery( function ( $ ) {
     } );
 
     return;
-
-    // Initialise PayPal when page is ready.
-    jQuery( document ).ready(function() {
-
-        let paypalButtonProps = {
-            onApprove: async function (data) {
-
-                jQuery('.woocommerce').block({message: null, overlayCSS: {background: '#fff', opacity: 0.6}});
-
-                jQuery.post(cko_paypal_vars.cc_capture + "&paypal_order_id=" + data.orderID + "&woocommerce-process-checkout-nonce=" + cko_paypal_vars.woocommerce_process_checkout, function (data) {
-                    if (typeof data.success !== 'undefined' && data.success !== true ) {
-                        var messages = data.data.messages ? data.data.messages : data.data;
-
-                        if ( 'string' === typeof messages || Array.isArray( messages ) ) {
-                            showError( messages );
-                        }
-                    } else {
-                        window.location.href = data.data.redirect;
-                    }
-                });
-            },
-            onCancel: function (data, actions) {
-                jQuery('.woocommerce').unblock();
-            },
-            onError: function (err) {
-                console.log(err);
-                jQuery('.woocommerce').unblock();
-            },
-        };
-
-        if ( cko_paypal_vars.is_cart_contains_subscription ) {
-            paypalButtonProps.createBillingAgreement = function( data, actions ) {
-                return cko_create_order_id();
-            };
-        } else {
-            paypalButtonProps.createOrder = function( data, actions ) {
-                return cko_create_order_id();
-            };
-        }
-
-        paypal.Buttons({ paypalButtonProps }).render( cko_paypal_vars.paypal_button_selector );
-    });
-
-
-
 });

--- a/includes/class-wc-gateway-checkout-com-paypal.php
+++ b/includes/class-wc-gateway-checkout-com-paypal.php
@@ -86,8 +86,7 @@ class WC_Gateway_Checkout_Com_PayPal extends WC_Payment_Gateway {
 					}
 					break;
 				
-					case 'empty_session':
-					error_log(print_r($_SESSION,true));
+				case 'empty_session':
 					WC_Checkoutcom_Utility::cko_set_session( 'cko_paypal_order_id', '' );
 					WC_Checkoutcom_Utility::cko_set_session( 'cko_pc_id', '' );
 
@@ -540,7 +539,7 @@ class WC_Gateway_Checkout_Com_PayPal extends WC_Payment_Gateway {
 
 		$vars = [
 			'create_order_url'              => add_query_arg( [ 'cko_paypal_action' => 'create_order' ], WC()->api_request_url( 'CKO_Paypal_Woocommerce' ) ),
-			'clear_session_url'				=> add_query_arg( [ 'cko_paypal_action' => 'empty_session' ], WC()->api_request_url( 'CKO_Paypal_Woocommerce' ) ),
+			'clear_session_url'             => add_query_arg( [ 'cko_paypal_action' => 'empty_session' ], WC()->api_request_url( 'CKO_Paypal_Woocommerce' ) ),
 			'cc_capture'                    => add_query_arg( [ 'cko_paypal_action' => 'cc_capture' ], WC()->api_request_url( 'CKO_Paypal_Woocommerce' ) ),
 			'woocommerce_process_checkout'  => wp_create_nonce( 'woocommerce-process_checkout' ),
 			'is_cart_contains_subscription' => WC_Checkoutcom_Utility::is_cart_contains_subscription(),

--- a/includes/class-wc-gateway-checkout-com-paypal.php
+++ b/includes/class-wc-gateway-checkout-com-paypal.php
@@ -85,6 +85,11 @@ class WC_Gateway_Checkout_Com_PayPal extends WC_Payment_Gateway {
 						exit();
 					}
 					break;
+				
+					case 'empty_session':
+					error_log(print_r($_SESSION,true));
+					WC_Checkoutcom_Utility::cko_set_session( 'cko_paypal_order_id', '' );
+					WC_Checkoutcom_Utility::cko_set_session( 'cko_pc_id', '' );
 
 				case 'cc_capture':
 					WC_Checkoutcom_Utility::cko_set_session( 'cko_paypal_order_id', wc_clean( $_GET['paypal_order_id'] ) );
@@ -535,6 +540,7 @@ class WC_Gateway_Checkout_Com_PayPal extends WC_Payment_Gateway {
 
 		$vars = [
 			'create_order_url'              => add_query_arg( [ 'cko_paypal_action' => 'create_order' ], WC()->api_request_url( 'CKO_Paypal_Woocommerce' ) ),
+			'clear_session_url'				=> add_query_arg( [ 'cko_paypal_action' => 'empty_session' ], WC()->api_request_url( 'CKO_Paypal_Woocommerce' ) ),
 			'cc_capture'                    => add_query_arg( [ 'cko_paypal_action' => 'cc_capture' ], WC()->api_request_url( 'CKO_Paypal_Woocommerce' ) ),
 			'woocommerce_process_checkout'  => wp_create_nonce( 'woocommerce-process_checkout' ),
 			'is_cart_contains_subscription' => WC_Checkoutcom_Utility::is_cart_contains_subscription(),


### PR DESCRIPTION
- Clear the paypal session key to not reuse them on 2nd attempt
- Make an ajax call on Cancel and return of Paypal Payment