### PR TITLE
Fix: order pay

### DIFF
--- a/assets/js/cko-paypal-integration.js
+++ b/assets/js/cko-paypal-integration.js
@@ -56,19 +56,38 @@ jQuery( function ( $ ) {
             .addClass( 'woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout' )
             .append( ulWrapper );
 
-        jQuery('form.checkout .woocommerce-NoticeGroup').remove();
-        jQuery('form.checkout').prepend(wcNoticeDiv);
-        jQuery('.woocommerce, .form.checkout').removeClass('processing').unblock();
+        let scrollTarget;
 
-        jQuery('html, body').animate({
-            scrollTop: (jQuery('form.checkout').offset().top - 100 )
-        }, 1000 );
+        if ( jQuery('form.checkout').length ) {
+            jQuery('form.checkout .woocommerce-NoticeGroup').remove();
+            jQuery('form.checkout').prepend(wcNoticeDiv);
+            jQuery('.woocommerce, .form.checkout').removeClass('processing').unblock();
+            scrollTarget = jQuery('form.checkout');
+        } else if ( jQuery('.woocommerce-order-pay').length ) {
+            jQuery('.woocommerce-order-pay .woocommerce-NoticeGroup').remove();
+            jQuery('.woocommerce-order-pay').prepend(wcNoticeDiv);
+            jQuery('.woocommerce, .woocommerce-order-pay').removeClass('processing').unblock();
+            scrollTarget = jQuery('.woocommerce-order-pay');
+        }
+    
+        if ( scrollTarget ) {
+            jQuery('html, body').animate({
+                scrollTop: (scrollTarget.offset().top - 100)
+            }, 1000);
+        }
     };
 
     let cko_create_order_id = function () {
         let data = jQuery( cko_paypal_vars.paypal_button_selector ).closest('form').serialize();
 
-        return fetch( cko_paypal_vars.create_order_url, {
+        var cko_url = cko_paypal_vars.create_order_url;
+
+        var isOrderPayPage = jQuery(document.body).hasClass('woocommerce-order-pay');
+        if (isOrderPayPage){
+            cko_url = cko_paypal_vars.order_pay_url;
+        }
+
+        return fetch( cko_url, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded'
@@ -96,7 +115,13 @@ jQuery( function ( $ ) {
             jQuery( '#payment #paypal-button-container' ).remove();
 
             if ( ! jQuery( '#payment' ).find( '#paypal-button-container' ).length ) {
-                jQuery( '#payment .place-order' ).append( '<div id="paypal-button-container" style="margin-top:15px; display:none;"></div>' );
+                var isOrderPayPage = jQuery(document.body).hasClass('woocommerce-order-pay');
+                if( isOrderPayPage ) {
+                    jQuery( '#payment > .form-row' ).append( '<div id="paypal-button-container" style="margin-top:15px; display:none;"></div>' );
+                }
+                else {
+                    jQuery( '#payment .place-order' ).append( '<div id="paypal-button-container" style="margin-top:15px; display:none;"></div>' );
+                }
             }
 
             // Initialize paypal button.

--- a/includes/class-wc-gateway-checkout-com-google-pay.php
+++ b/includes/class-wc-gateway-checkout-com-google-pay.php
@@ -70,6 +70,26 @@ class WC_Gateway_Checkout_Com_Google_Pay extends WC_Payment_Gateway {
 			$currency_code = get_woocommerce_currency();
 			$total_price   = WC()->cart->total;
 
+			// Logic for order-pay page.
+			// If on order-pay page, try fetching order total from the last order.
+			if ( is_wc_endpoint_url( 'order-pay' ) ) {
+
+				global $wp;
+
+				// Get order ID from URL if available.
+				$order_id = absint( $wp->query_vars['order-pay'] );
+
+				if ( ! $order_id && isset( $_GET['key'] ) ) {
+					$pay_order = wc_get_order( wc_get_order_id_by_order_key( sanitize_text_field( $_GET['key'] ) ) );
+				} else {
+					$pay_order = wc_get_order( $order_id );
+				}
+
+				if ( $pay_order ) {
+					$total_price = $pay_order->get_total();
+				}
+			}
+
 			$vars = [
 				'environment'   => $environment ? 'TEST' : 'PRODUCTION',
 				'public_key'    => $core_settings['ckocom_pk'],

--- a/languages/checkout-com-unified-payments-api.pot
+++ b/languages/checkout-com-unified-payments-api.pot
@@ -1,15 +1,15 @@
-# Copyright (C) 2024 Checkout.com
+# Copyright (C) 2025 Checkout.com
 # This file is distributed under the same license as the Checkout.com Payment Gateway plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Checkout.com Payment Gateway 4.9.0\n"
+"Project-Id-Version: Checkout.com Payment Gateway 4.9.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-gateway-checkout-com\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-11-19T08:15:04+00:00\n"
+"POT-Creation-Date: 2025-03-18T12:22:31+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.9.0\n"
 "X-Domain: checkout-com-unified-payments-api\n"
@@ -345,21 +345,21 @@ msgstr ""
 #: includes/class-wc-gateway-checkout-com-alternative-payments.php:67
 #: includes/class-wc-gateway-checkout-com-apple-pay.php:66
 #: includes/class-wc-gateway-checkout-com-cards.php:178
-#: includes/class-wc-gateway-checkout-com-google-pay.php:101
-#: includes/class-wc-gateway-checkout-com-paypal.php:458
+#: includes/class-wc-gateway-checkout-com-google-pay.php:121
+#: includes/class-wc-gateway-checkout-com-paypal.php:486
 msgid "Other Settings"
 msgstr ""
 
 #. translators: %s: Action ID.
 #: includes/class-wc-gateway-checkout-com-alternative-payments.php:123
-#: includes/class-wc-gateway-checkout-com-apple-pay.php:642
+#: includes/class-wc-gateway-checkout-com-apple-pay.php:676
 #: includes/class-wc-gateway-checkout-com-cards.php:948
 msgid "Checkout.com Payment Partially refunded from Admin - Action ID : %s"
 msgstr ""
 
 #. translators: %s: Action ID.
 #: includes/class-wc-gateway-checkout-com-alternative-payments.php:132
-#: includes/class-wc-gateway-checkout-com-apple-pay.php:651
+#: includes/class-wc-gateway-checkout-com-apple-pay.php:685
 #: includes/class-wc-gateway-checkout-com-cards.php:943
 msgid "Checkout.com Payment refunded from Admin - Action ID : %s"
 msgstr ""
@@ -369,25 +369,25 @@ msgstr ""
 msgid "Apple Pay"
 msgstr ""
 
-#: includes/class-wc-gateway-checkout-com-apple-pay.php:557
+#: includes/class-wc-gateway-checkout-com-apple-pay.php:591
 #: includes/class-wc-gateway-checkout-com-cards.php:467
-#: includes/class-wc-gateway-checkout-com-google-pay.php:152
+#: includes/class-wc-gateway-checkout-com-google-pay.php:172
 msgid "There was an issue completing the payment."
 msgstr ""
 
 #. translators: %s: Action ID.
-#: includes/class-wc-gateway-checkout-com-apple-pay.php:585
+#: includes/class-wc-gateway-checkout-com-apple-pay.php:619
 #: includes/class-wc-gateway-checkout-com-cards.php:551
 #: includes/class-wc-gateway-checkout-com-cards.php:660
-#: includes/class-wc-gateway-checkout-com-google-pay.php:195
+#: includes/class-wc-gateway-checkout-com-google-pay.php:215
 msgid "Checkout.com Payment Authorised - Action ID : %s"
 msgstr ""
 
 #. translators: %s: Action ID.
-#: includes/class-wc-gateway-checkout-com-apple-pay.php:593
+#: includes/class-wc-gateway-checkout-com-apple-pay.php:627
 #: includes/class-wc-gateway-checkout-com-cards.php:559
 #: includes/class-wc-gateway-checkout-com-cards.php:668
-#: includes/class-wc-gateway-checkout-com-google-pay.php:203
+#: includes/class-wc-gateway-checkout-com-google-pay.php:223
 msgid "Checkout.com Payment Flagged - Action ID : %s"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 
 #. translators: %s: URL
 #: includes/class-wc-gateway-checkout-com-cards.php:513
-#: includes/class-wc-gateway-checkout-com-google-pay.php:165
+#: includes/class-wc-gateway-checkout-com-google-pay.php:185
 msgid "Checkout.com 3d Redirect waiting. URL : %s"
 msgstr ""
 
@@ -492,14 +492,14 @@ msgid "Google Pay"
 msgstr ""
 
 #. translators: %s: Action ID.
-#: includes/class-wc-gateway-checkout-com-google-pay.php:250
-#: includes/class-wc-gateway-checkout-com-paypal.php:600
+#: includes/class-wc-gateway-checkout-com-google-pay.php:270
+#: includes/class-wc-gateway-checkout-com-paypal.php:629
 msgid "Checkout.com Payment refunded - Action ID : %s"
 msgstr ""
 
 #. translators: %s: Action ID.
-#: includes/class-wc-gateway-checkout-com-google-pay.php:255
-#: includes/class-wc-gateway-checkout-com-paypal.php:605
+#: includes/class-wc-gateway-checkout-com-google-pay.php:275
+#: includes/class-wc-gateway-checkout-com-paypal.php:634
 msgid "Checkout.com Payment Partially refunded - Action ID : %s"
 msgstr ""
 
@@ -509,8 +509,8 @@ msgstr ""
 msgid "PayPal"
 msgstr ""
 
-#: includes/class-wc-gateway-checkout-com-paypal.php:390
-#: includes/class-wc-gateway-checkout-com-paypal.php:432
+#: includes/class-wc-gateway-checkout-com-paypal.php:418
+#: includes/class-wc-gateway-checkout-com-paypal.php:460
 msgid "An error has occurred while PayPal payment request. "
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -171,6 +171,9 @@ http://example.com/?wc-api=wc_checkoutcom_webhook
 After the plugin has been configured, customers will be able to choose Checkout.com as a valid payment method.
 
 == Changelog ==
+v4.9.1 18th March 2024
+- **[fix]** Payment gateways on `order-pay` page
+
 v4.9.0 19th Novemeber 2024
 - **[fix]** 422 error on Paypal Payment Gateway
 

--- a/woocommerce-gateway-checkout-com.php
+++ b/woocommerce-gateway-checkout-com.php
@@ -5,10 +5,10 @@
  * Description: Extends WooCommerce by Adding the Checkout.com Gateway.
  * Author: Checkout.com
  * Author URI: https://www.checkout.com/
- * Version: 4.9.0
+ * Version: 4.9.1
  * Requires Plugins: woocommerce
  * Requires at least: 5.0
- * Stable tag: 4.9.0
+ * Stable tag: 4.9.1
  * Tested up to: 6.7.0
  * WC tested up to: 8.3.1
  * Requires PHP: 7.3
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Constants.
  */
-define( 'WC_CHECKOUTCOM_PLUGIN_VERSION', '4.9.0' );
+define( 'WC_CHECKOUTCOM_PLUGIN_VERSION', '4.9.1' );
 define( 'WC_CHECKOUTCOM_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'WC_CHECKOUTCOM_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 


### PR DESCRIPTION
## Changes made

### Add fixes for payment gateways on order-pay page
- Fix `PayPal` working on `order-pay` page and enable the button there
- Fix `Apple Pay` and `Google Pay` working on `order-pay` page to show the correct total amount of the order.

### Change version of Plugin to `v4.9.1`
- Update changelog
- generate a new `.pot` file.