### PR TITLE
Feat: Add Apple pay Payment on all browsers

### DIFF
--- a/assets/css/checkoutcom-styles.css
+++ b/assets/css/checkoutcom-styles.css
@@ -54,37 +54,13 @@
     }
 }
 /* This is the CSS needed to the the ApplePay Button -> */
-.apple-pay-button {
-    width: var(--wallet-button-width);
-    height: var(--wallet-button-height);
-    display: inline-block;
-    -webkit-appearance: -apple-pay-button;
-    cursor: pointer;
+apple-pay-button {
+    --apple-pay-button-width: var(--wallet-button-width);
+    --apple-pay-button-height: var(--wallet-button-height);
+    --apple-pay-button-border-radius: 3px;
+    --apple-pay-button-padding: 2px 0px;
+    --apple-pay-button-box-sizing: border-box;
     margin-top: 15px;
-}
-.apple-pay-button-with-text > * {
-    display: none;
-}
-.apple-pay-button-black-with-text {
-    -apple-pay-button-style: black;
-}
-.apple-pay-button-white-with-text {
-    -apple-pay-button-style: white;
-}
-.apple-pay-button-white-with-line-with-text {
-    -apple-pay-button-style: white-outline;
-}
-.apple-pay-button-text-book {
-    -apple-pay-button-type: book;
-}
-.apple-pay-button-text-buy {
-    -apple-pay-button-type: buy;
-}
-.apple-pay-button-text-check-out {
-    -apple-pay-button-type: check-out;
-}
-.apple-pay-button-text-donate {
-    -apple-pay-button-type: donate;
 }
 
 /* For mobile devices */

--- a/includes/class-wc-gateway-checkout-com-apple-pay.php
+++ b/includes/class-wc-gateway-checkout-com-apple-pay.php
@@ -152,7 +152,7 @@ class WC_Gateway_Checkout_Com_Apple_Pay extends WC_Payment_Gateway {
 			// Display the button and remove the default place order.
 			checkoutInitialiseApplePay = function () {
 				jQuery( '#payment' ) . append(
-					'<apple-pay-button id="' + applePayButtonId + '" type="' 
+					'<apple-pay-button id="' + applePayButtonId + '" onclick="onApplePayButtonClicked()" type="' 
 					+ "<?php echo esc_js( $this->get_option( 'ckocom_apple_type' ) ); ?>" + '" buttonstyle="' 
 					+ "<?php echo esc_js( $this->get_option( 'ckocom_apple_theme' ) ); ?>" + '" locale="' 
 					+ "<?php echo esc_js( $this->get_option( 'ckocom_apple_language' ) ); ?>" + '"></apple-pay-button>'
@@ -162,18 +162,16 @@ class WC_Gateway_Checkout_Com_Apple_Pay extends WC_Payment_Gateway {
 			};
 
 			// Listen for when the Apple Pay button is pressed.
-			jQuery( document ).off( 'click', '#' + applePayButtonId );
-
-			jQuery( document ).on( 'click', '#' + applePayButtonId, function () {
+			function onApplePayButtonClicked() {
 				var checkoutFields = '<?php echo $checkout_fields; ?>';
 				var result = isValidFormField(checkoutFields);
 
-				if(result){
+				if (result) {
 					var applePaySession = new ApplePaySession(3, getApplePayConfig());
 					handleApplePayEvents(applePaySession);
 					applePaySession.begin();
-				}
-			});
+				} 
+			}
 
 			/**
 			 * Get the configuration needed to initialise the Apple Pay session.

--- a/includes/class-wc-gateway-checkout-com-apple-pay.php
+++ b/includes/class-wc-gateway-checkout-com-apple-pay.php
@@ -118,6 +118,10 @@ class WC_Gateway_Checkout_Com_Apple_Pay extends WC_Payment_Gateway {
 		<p style="display:none" id="ckocom_applePay_not_actived">ApplePay is possible on this browser, but not currently activated.</p>
 		<p style="display:none" id="ckocom_applePay_not_possible">ApplePay is not available on this browser</p>
 
+		<script crossorigin
+            src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"
+        ></script>
+
 		<script type="text/javascript">
 			// Magic strings used in file
 			var applePayOptionSelector = 'li.payment_method_wc_checkout_com_apple_pay';
@@ -147,10 +151,12 @@ class WC_Gateway_Checkout_Com_Apple_Pay extends WC_Payment_Gateway {
 
 			// Display the button and remove the default place order.
 			checkoutInitialiseApplePay = function () {
-				jQuery('#payment').append('<div id="' + applePayButtonId + '" class="apple-pay-button '
-				+ "<?php echo esc_js( $this->get_option( 'ckocom_apple_type' ) ); ?>" + " "
-				+ "<?php echo esc_js( $this->get_option( 'ckocom_apple_theme' ) ); ?>"  + '" lang="'
-				+ "<?php echo esc_js( $this->get_option( 'ckocom_apple_language' ) ); ?>" + '"></div>');
+				jQuery( '#payment' ) . append(
+					'<apple-pay-button id="' + applePayButtonId + '" type="' 
+					+ "<?php echo esc_js( $this->get_option( 'ckocom_apple_type' ) ); ?>" + '" buttonstyle="' 
+					+ "<?php echo esc_js( $this->get_option( 'ckocom_apple_theme' ) ); ?>" + '" locale="' 
+					+ "<?php echo esc_js( $this->get_option( 'ckocom_apple_language' ) ); ?>" + '"></apple-pay-button>'
+				);
 
 				jQuery('#ckocom_applePay').hide();
 			};

--- a/includes/settings/class-wc-checkoutcom-cards-settings.php
+++ b/includes/settings/class-wc-checkoutcom-cards-settings.php
@@ -546,26 +546,26 @@ class WC_Checkoutcom_Cards_Settings {
 				'desc_tip'    => true,
 				'default'     => '',
 			],
-			'ckocom_apple_type'        => [
+			'ckocom_apple_type'        => array(
 				'title'   => __( 'Button Type', 'checkout-com-unified-payments-api' ),
 				'type'    => 'select',
-				'options' => [
-					'apple-pay-button-text-buy'       => __( 'Buy', 'checkout-com-unified-payments-api' ),
-					'apple-pay-button-text-check-out' => __( 'Checkout out', 'checkout-com-unified-payments-api' ),
-					'apple-pay-button-text-book'      => __( 'Book', 'checkout-com-unified-payments-api' ),
-					'apple-pay-button-text-donate'    => __( 'Donate', 'checkout-com-unified-payments-api' ),
-					'apple-pay-button'                => __( 'Plain', 'checkout-com-unified-payments-api' ),
-				],
-			],
-			'ckocom_apple_theme'       => [
+				'options' => array(
+					'buy'       => __( 'Buy', 'checkout-com-unified-payments-api' ),
+					'check-out' => __( 'Checkout', 'checkout-com-unified-payments-api' ),
+					'book'      => __( 'Book', 'checkout-com-unified-payments-api' ),
+					'donate'    => __( 'Donate', 'checkout-com-unified-payments-api' ),
+					'plain'     => __( 'Plain', 'checkout-com-unified-payments-api' ),
+				),
+			),
+			'ckocom_apple_theme'       => array(
 				'title'   => __( 'Button Theme', 'checkout-com-unified-payments-api' ),
 				'type'    => 'select',
-				'options' => [
-					'apple-pay-button-black-with-text' => __( 'Black', 'checkout-com-unified-payments-api' ),
-					'apple-pay-button-white-with-text' => __( 'White', 'checkout-com-unified-payments-api' ),
-					'apple-pay-button-white-with-line-with-text' => __( 'White with outline', 'checkout-com-unified-payments-api' ),
-				],
-			],
+				'options' => array(
+					'black'         => __( 'Black', 'checkout-com-unified-payments-api' ),
+					'white'         => __( 'White', 'checkout-com-unified-payments-api' ),
+					'white-outline' => __( 'White with outline', 'checkout-com-unified-payments-api' ),
+				),
+			),
 			'ckocom_apple_language'    => [
 				'title'       => __( 'Button Language', 'checkout-com-unified-payments-api' ),
 				'type'        => 'text',

--- a/languages/checkout-com-unified-payments-api.pot
+++ b/languages/checkout-com-unified-payments-api.pot
@@ -1,15 +1,15 @@
-# Copyright (C) 2024 Checkout.com
+# Copyright (C) 2025 Checkout.com
 # This file is distributed under the same license as the Checkout.com Payment Gateway plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Checkout.com Payment Gateway 4.9.0\n"
+"Project-Id-Version: Checkout.com Payment Gateway 4.9.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-gateway-checkout-com\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-11-19T08:15:04+00:00\n"
+"POT-Creation-Date: 2025-03-25T08:33:57+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.9.0\n"
 "X-Domain: checkout-com-unified-payments-api\n"
@@ -345,21 +345,21 @@ msgstr ""
 #: includes/class-wc-gateway-checkout-com-alternative-payments.php:67
 #: includes/class-wc-gateway-checkout-com-apple-pay.php:66
 #: includes/class-wc-gateway-checkout-com-cards.php:178
-#: includes/class-wc-gateway-checkout-com-google-pay.php:101
-#: includes/class-wc-gateway-checkout-com-paypal.php:458
+#: includes/class-wc-gateway-checkout-com-google-pay.php:121
+#: includes/class-wc-gateway-checkout-com-paypal.php:486
 msgid "Other Settings"
 msgstr ""
 
 #. translators: %s: Action ID.
 #: includes/class-wc-gateway-checkout-com-alternative-payments.php:123
-#: includes/class-wc-gateway-checkout-com-apple-pay.php:642
+#: includes/class-wc-gateway-checkout-com-apple-pay.php:680
 #: includes/class-wc-gateway-checkout-com-cards.php:948
 msgid "Checkout.com Payment Partially refunded from Admin - Action ID : %s"
 msgstr ""
 
 #. translators: %s: Action ID.
 #: includes/class-wc-gateway-checkout-com-alternative-payments.php:132
-#: includes/class-wc-gateway-checkout-com-apple-pay.php:651
+#: includes/class-wc-gateway-checkout-com-apple-pay.php:689
 #: includes/class-wc-gateway-checkout-com-cards.php:943
 msgid "Checkout.com Payment refunded from Admin - Action ID : %s"
 msgstr ""
@@ -369,25 +369,25 @@ msgstr ""
 msgid "Apple Pay"
 msgstr ""
 
-#: includes/class-wc-gateway-checkout-com-apple-pay.php:557
+#: includes/class-wc-gateway-checkout-com-apple-pay.php:595
 #: includes/class-wc-gateway-checkout-com-cards.php:467
-#: includes/class-wc-gateway-checkout-com-google-pay.php:152
+#: includes/class-wc-gateway-checkout-com-google-pay.php:172
 msgid "There was an issue completing the payment."
 msgstr ""
 
 #. translators: %s: Action ID.
-#: includes/class-wc-gateway-checkout-com-apple-pay.php:585
+#: includes/class-wc-gateway-checkout-com-apple-pay.php:623
 #: includes/class-wc-gateway-checkout-com-cards.php:551
 #: includes/class-wc-gateway-checkout-com-cards.php:660
-#: includes/class-wc-gateway-checkout-com-google-pay.php:195
+#: includes/class-wc-gateway-checkout-com-google-pay.php:215
 msgid "Checkout.com Payment Authorised - Action ID : %s"
 msgstr ""
 
 #. translators: %s: Action ID.
-#: includes/class-wc-gateway-checkout-com-apple-pay.php:593
+#: includes/class-wc-gateway-checkout-com-apple-pay.php:631
 #: includes/class-wc-gateway-checkout-com-cards.php:559
 #: includes/class-wc-gateway-checkout-com-cards.php:668
-#: includes/class-wc-gateway-checkout-com-google-pay.php:203
+#: includes/class-wc-gateway-checkout-com-google-pay.php:223
 msgid "Checkout.com Payment Flagged - Action ID : %s"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 
 #. translators: %s: URL
 #: includes/class-wc-gateway-checkout-com-cards.php:513
-#: includes/class-wc-gateway-checkout-com-google-pay.php:165
+#: includes/class-wc-gateway-checkout-com-google-pay.php:185
 msgid "Checkout.com 3d Redirect waiting. URL : %s"
 msgstr ""
 
@@ -492,14 +492,14 @@ msgid "Google Pay"
 msgstr ""
 
 #. translators: %s: Action ID.
-#: includes/class-wc-gateway-checkout-com-google-pay.php:250
-#: includes/class-wc-gateway-checkout-com-paypal.php:600
+#: includes/class-wc-gateway-checkout-com-google-pay.php:270
+#: includes/class-wc-gateway-checkout-com-paypal.php:629
 msgid "Checkout.com Payment refunded - Action ID : %s"
 msgstr ""
 
 #. translators: %s: Action ID.
-#: includes/class-wc-gateway-checkout-com-google-pay.php:255
-#: includes/class-wc-gateway-checkout-com-paypal.php:605
+#: includes/class-wc-gateway-checkout-com-google-pay.php:275
+#: includes/class-wc-gateway-checkout-com-paypal.php:634
 msgid "Checkout.com Payment Partially refunded - Action ID : %s"
 msgstr ""
 
@@ -509,8 +509,8 @@ msgstr ""
 msgid "PayPal"
 msgstr ""
 
-#: includes/class-wc-gateway-checkout-com-paypal.php:390
-#: includes/class-wc-gateway-checkout-com-paypal.php:432
+#: includes/class-wc-gateway-checkout-com-paypal.php:418
+#: includes/class-wc-gateway-checkout-com-paypal.php:460
 msgid "An error has occurred while PayPal payment request. "
 msgstr ""
 
@@ -1034,7 +1034,7 @@ msgid "Buy"
 msgstr ""
 
 #: includes/settings/class-wc-checkoutcom-cards-settings.php:554
-msgid "Checkout out"
+msgid "Checkout"
 msgstr ""
 
 #: includes/settings/class-wc-checkoutcom-cards-settings.php:555

--- a/readme.txt
+++ b/readme.txt
@@ -171,6 +171,9 @@ http://example.com/?wc-api=wc_checkoutcom_webhook
 After the plugin has been configured, customers will be able to choose Checkout.com as a valid payment method.
 
 == Changelog ==
+v4.9.2 25th March 2025
+- **[feat]** Enable Apple-pay on all browsers
+
 v4.9.0 19th Novemeber 2024
 - **[fix]** 422 error on Paypal Payment Gateway
 

--- a/woocommerce-gateway-checkout-com.php
+++ b/woocommerce-gateway-checkout-com.php
@@ -5,10 +5,10 @@
  * Description: Extends WooCommerce by Adding the Checkout.com Gateway.
  * Author: Checkout.com
  * Author URI: https://www.checkout.com/
- * Version: 4.9.0
+ * Version: 4.9.2
  * Requires Plugins: woocommerce
  * Requires at least: 5.0
- * Stable tag: 4.9.0
+ * Stable tag: 4.9.2
  * Tested up to: 6.7.0
  * WC tested up to: 8.3.1
  * Requires PHP: 7.3
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Constants.
  */
-define( 'WC_CHECKOUTCOM_PLUGIN_VERSION', '4.9.0' );
+define( 'WC_CHECKOUTCOM_PLUGIN_VERSION', '4.9.2' );
 define( 'WC_CHECKOUTCOM_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'WC_CHECKOUTCOM_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 


### PR DESCRIPTION
## Changes made

### Enable Apple-pay on all browsers
- Add `Apple-pay` new js sdk to enable it on all browsers
- Change CSS of `Apple Pay` Button to be compatible with all browsers
- Change the `apple-pay-button` generated element and php `apple-pay` settings values for compatibility across browsers

### Change version of Plugin to `v4.9.2`
- Update changelog
- generate a new `.pot` file.