### PR TITLE
feat: Add payment session ID and payment ID protection

### DIFF
--- a/checkout-com-unified-payments-api/readme.txt
+++ b/checkout-com-unified-payments-api/readme.txt
@@ -2,7 +2,7 @@
 Contributors: checkoutintegration
 Tags: checkout, payments, credit card, payment gateway, apple pay, google pay, payment request
 Requires at least: 5.0
-Stable tag: 5.0.0_beta
+Stable tag: 5.0.0
 Requires PHP: 7.3
 Tested up to: 6.7.0
 License: GPLv2 or later


### PR DESCRIPTION
- Prevent overwriting _cko_flow_payment_id if already exists
- Prevent overwriting _cko_payment_session_id if already exists
- Add checks in handle_3ds_return() and process_payment()
- Improve webhook matching reliability for APM payments
- Fix payment session ID not being saved for APM orders
- Add comprehensive logging for debugging
- Update readme.txt stable tag to 5.0.0

Version: 5.0.0 (bug fixes and improvements)